### PR TITLE
Make sure that only declared params are piped through to business processes

### DIFF
--- a/lib/epics/box/content.rb
+++ b/lib/epics/box/content.rb
@@ -124,7 +124,7 @@ module Epics
         end
         post 'debits' do
           params[:requested_date] ||= Time.now.to_i + 172800 # grape defaults interfere with swagger doc creation
-          DirectDebit.create!(account, params, current_user)
+          DirectDebit.create!(account, declared(params), current_user)
           { message: 'Direct debit has been initiated successfully!' }
         end
 
@@ -154,7 +154,7 @@ module Epics
         end
         post 'credits' do
           params[:requested_date] ||= Time.now.to_i # grape defaults interfere with swagger doc creation
-          Credit.create!(account, params, current_user)
+          Credit.create!(account, declared(params), current_user)
           { message: 'Credit has been initiated successfully!' }
         end
 


### PR DESCRIPTION
Without that, all params are handed down deep into the app, causing crashes when added to database.
