### PR TITLE
Fallback to non-T-subscribers when no other is available

### DIFF
--- a/lib/epics/box/adapters/fake.rb
+++ b/lib/epics/box/adapters/fake.rb
@@ -4,7 +4,11 @@ module Epics
   module Box
     module Adapters
       class Fake
-        def initialize(*args); end
+        attr_accessor :setup_args
+
+        def initialize(*args)
+          self.setup_args = args
+        end
 
         def self.setup(*args)
           return new(*args)

--- a/spec/epics/box/models/account_spec.rb
+++ b/spec/epics/box/models/account_spec.rb
@@ -3,6 +3,50 @@ require 'active_support/all'
 module Epics
   module Box
     RSpec.describe Account do
+
+      describe '#transport_client' do
+        subject(:account) { described_class.create(mode: "Fake") }
+
+        context 'no subscriber added' do
+          it 'fails with an no transport client exceptiopn' do
+            expect { account.transport_client }.to raise_error(Account::NoTransportClient)
+          end
+        end
+
+        context 'no activated subscriber available' do
+          before { account.add_subscriber(activated_at: nil) }
+
+          it 'fails with an no transport client exceptiopn' do
+            expect { account.transport_client }.to raise_error(Account::NoTransportClient)
+          end
+        end
+
+        context 'activated T and another subscriber available' do
+          before do
+            account.add_subscriber(remote_user_id: 'E-USER', signature_class: 'E', activated_at: Date.new(2015, 1, 1))
+            account.add_subscriber(remote_user_id: 'T-USER', signature_class: 'T', activated_at: Date.new(2015, 1, 1))
+          end
+
+          it 'returns a client instance' do
+            expect(account.transport_client).to respond_to(:STA)
+          end
+
+          it 'returns the T signature class client' do
+            expect(account.transport_client.setup_args).to include('T-USER')
+          end
+        end
+
+        context 'no activated T subscriber' do
+          before do
+            account.add_subscriber(signature_class: 'E', activated_at: Date.new(2015, 1, 1))
+          end
+
+          it 'falls back to non-T subscriber' do
+            expect(account.transport_client).to respond_to(:STA)
+          end
+        end
+      end
+
       describe '.all_active_ids' do
         it 'returns an empty array if no accounts are created yet' do
           expect(described_class.all_active_ids).to eq([])


### PR DESCRIPTION
Some companies might not have a T-subscriber for accessing their accounts. In those cases we just fallback to the first non-T subscriber to fetch statements etc.
