### PR TITLE
Remove host specification for swagger documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,6 @@ RUN npm install
 RUN webpack -p
 #RUN rake jruby:build
 
-# Generate documentation
-RUN sed -i.bak 's/localhost:80/ebics-box-test\.apps\.railslabs\.com:443/g' doc/swagger/swagger.json
-
 # Clean up
 RUN rm Dockerfile*
 RUN rm Rakefile

--- a/config.ru
+++ b/config.ru
@@ -19,7 +19,9 @@ box = Rack::Builder.app do
   end
 
   use Rack::Static, urls: ["/images", "/lib", "/fonts", "/js", "/css", "/swagger-ui.js"], root: "public/swagger"
-  use Rack::Static, urls: ["/swagger.json"], root: "doc/swagger"
+  use Rack::Static, urls: ["/swagger.json"], root: "doc/swagger", header_rules: [
+    [:all, {'Access-Control-Allow-Origin' => '*'}]
+  ]
 
   map '/docs' do
     run lambda { |env|

--- a/doc/swagger/base_doc.yml
+++ b/doc/swagger/base_doc.yml
@@ -74,9 +74,9 @@ info:
     email: contact@ebicsbox.com
     url: http://www.ebicsbox.com/
   version: '0.1'
-host: localhost:80
-basePath: "/"
+basePath: ""
 schemes:
+- http
 - https
 consumes:
 - application/json

--- a/doc/swagger/swagger.json
+++ b/doc/swagger/swagger.json
@@ -11,9 +11,9 @@
     },
     "version": "0.1"
   },
-  "host": "localhost:80",
-  "basePath": "//",
+  "basePath": "/",
   "schemes": [
+    "http",
     "https"
   ],
   "consumes": [
@@ -1215,6 +1215,10 @@
         "account": {
           "type": "string",
           "description": "Display name for given bank account"
+        },
+        "id": {
+          "type": "integer",
+          "description": "Internal id"
         },
         "user_id": {
           "type": "string",


### PR DESCRIPTION
By removing host and port swagger uses the current host to access its specification file. By doing so, we do not need to set those values for every different deploy.
