### PR TITLE
Use correct OAuth bearer token keyword in headers

### DIFF
--- a/lib/epics/box/helpers/default.rb
+++ b/lib/epics/box/helpers/default.rb
@@ -7,7 +7,7 @@ module Epics
     module Helpers
       module Default
         def access_token
-          params['access_token'] || headers['Authorization'].to_s[/token (.+)/, 1]
+          params['access_token'] || headers['Authorization'].to_s[/\A(?:token|Bearer) (.+)\z/, 1]
         end
 
         def current_user

--- a/spec/epics/box/helpers/default_spec.rb
+++ b/spec/epics/box/helpers/default_spec.rb
@@ -32,21 +32,37 @@ module Epics
             expect(json_response).to eq(nil)
           end
 
-          it 'returns the header access token if provided' do
-            header "Authorization", "token header-token"
-            get '/access_token'
-            expect(json_response).to eq('header-token')
-          end
-
           it 'returns the url param access token if provided' do
             get '/access_token?access_token=url-token'
             expect(json_response).to eq('url-token')
           end
 
-          it 'returns the url token if both, header and url token, are provided' do
-            header "Authorization", "token header-token"
-            get '/access_token?access_token=url-token'
-            expect(json_response).to eq('url-token')
+          context 'invalid token keyword' do
+            it 'returns the header access token if provided' do
+              header "Authorization", "token header-token"
+              get '/access_token'
+              expect(json_response).to eq('header-token')
+            end
+
+            it 'returns the url token if both, header and url token, are provided' do
+              header "Authorization", "token header-token"
+              get '/access_token?access_token=url-token'
+              expect(json_response).to eq('url-token')
+            end
+          end
+
+          context 'proper oauth bearer token keyword' do
+            it 'returns the header access token if provided' do
+              header "Authorization", "Bearer header-token"
+              get '/access_token'
+              expect(json_response).to eq('header-token')
+            end
+
+            it 'returns the url token if both, header and url token, are provided' do
+              header "Authorization", "Bearer header-token"
+              get '/access_token?access_token=url-token'
+              expect(json_response).to eq('url-token')
+            end
           end
         end
       end


### PR DESCRIPTION
For some unknown reason, I implemented OAuth bearer token detection with an invalid keyword. This has been fixed and is backwards compatible.
