### PR TITLE
Load all ruby classes when starting a console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -10,5 +10,9 @@ Bundler.setup(:default, :development)
 
 # Start pry session
 require_relative '../config/bootstrap'
+
+# Load all files for console
+Dir[File.join(File.dirname(__FILE__), '../box/**/*.rb')].map { |file| require_relative(file.gsub('bin/', '')) }
+
 require 'pry'
 pry


### PR DESCRIPTION
Due to the refactoring, we didn't load all classes anymore. Pry wasn't the biggest help when making relative requires, so this commit should load all for us upfront.
