### PR TITLE
Set activation check interval for fake accounts to zero

### DIFF
--- a/box/business_processes/new_account.rb
+++ b/box/business_processes/new_account.rb
@@ -13,6 +13,7 @@ module Box
         # Always create fake accounts in sandbox mode
         if Box.configuration.sandbox?
           params[:mode] = "Fake"
+          params[:config] = { activation_check_interval: 0 }
         end
 
         DB.transaction do

--- a/spec/apis/v2/accounts_spec.rb
+++ b/spec/apis/v2/accounts_spec.rb
@@ -229,16 +229,32 @@ module Box
           expect_status 201
         end
 
-        it 'does not set fake mode for accounts created in regular mode' do
-          allow(Box.configuration).to receive(:sandbox?).and_return(false)
-          do_request
-          expect(Account.last.mode).to be_nil
+        context "when regular server mode" do
+          before { allow(Box.configuration).to receive(:sandbox?).and_return(false) }
+
+          it 'does not set fake mode' do
+            do_request
+            expect(Account.last.mode).to be_nil
+          end
+
+          it 'does not set a custom activation interval' do
+            do_request
+            expect(Account.last.config.activation_check_interval).to eq(Box.configuration.activation_check_interval)
+          end
         end
 
-        it 'sets fake mode for accounts created in sandbox mode' do
-          allow(Box.configuration).to receive(:sandbox?).and_return(true)
-          do_request
-          expect(Account.last.mode).to eq('Fake')
+        context "when sandbox server mode" do
+          before { allow(Box.configuration).to receive(:sandbox?).and_return(true) }
+
+          it 'sets fake mode' do
+            do_request
+            expect(Account.last.mode).to eq('Fake')
+          end
+
+          it 'sets custom activation interval to zero' do
+            do_request
+            expect(Account.last.config.activation_check_interval).to eq(0)
+          end
         end
       end
     end


### PR DESCRIPTION
There is no need to wait for fake accounts, as they always activate.
