### PR TITLE
make `triggered_at` an dynamic value

### DIFF
--- a/migrations/20171002125243_fix_event_default_timestamp.rb
+++ b/migrations/20171002125243_fix_event_default_timestamp.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  up do
+    set_column_default :events, :triggered_at, Sequel.function(:now)
+  end
+end


### PR DESCRIPTION
instead of a constant that is set when the table is created we want to use an expression that evaluates on runtime so we have the actual time stored in the DB