### PR TITLE
Adds auth support for authenticated Redis instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ AUTH_SERVICE=
 # when not using ebicsbox-internal db (e.g. not running with .with-db)
 DATABASE_URL=
 REDIS_URL=
+REDIS_PASSWORD=
 
 # when running with internal db, provide a path on your filesystem where the DB data should reside
 POSTGRES_USER=

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ If you want the box to be available via a custom (sub-)domain, also provide thes
 - `LETSENCRYPT_HOST`
 - `LETSENCRYPT_EMAIL`
 
+If you want to use a custom Redis instance provide the Redis conection strings:
+
+- `REDIS_URL` (redis://* for plain or rediss://* for ssl)
+- `REDIS_PASSWORD` (in case authentication is required)
+
 If you want to use a custom postgres instance provide the database connection strings:
 
 - `DATABASE_URL`

--- a/config/sidekiq.rb
+++ b/config/sidekiq.rb
@@ -45,7 +45,15 @@ if ENV['SENTRY_DSN']
   end
 end
 
+redis_conf = { url: ENV['REDIS_URL'], password:  ENV['REDIS_PASSWORD'] }
+
+Sidekiq.configure_client do |config|
+  config.redis = redis_conf
+end
+
 Sidekiq.configure_server do |config|
+
+  config.redis = redis_conf
   config.on(:startup) do
 
     if ENV.key?('UPDATE_BANK_STATEMENTS_INTERVAL')


### PR DESCRIPTION
I am currently setting Ebicsbox in Azure with SSL enabled authenticated Redis and I came across this limitation. 

Tested for 

1) Remote Redis , SSL enabled, Auth enabled
2) Local Redis with Docker, SSL disabled, Auth disabled

Let me know what you think. 