### PR TITLE
Adds refresh bank keys endpoint

### DIFF
--- a/box/apis/v2/management/ebics_users.rb
+++ b/box/apis/v2/management/ebics_users.rb
@@ -63,6 +63,18 @@ module Box
                 end
               end
 
+              params do
+                requires :id, type: Integer, desc: 'ID of the ebics_user'
+              end
+              post ':id/refresh_bank_keys' do
+                ebics_user = @account.ebics_users_dataset.first!(Sequel.qualify(:ebics_users, :id) => params[:id])
+                if ebics_user.refresh_bank_keys!
+                  present ebics_user, with: Entities::EbicsUser
+                else
+                  error!({ message: 'Bank keys could not be refreshed!' }, 500)
+                end
+              end
+
               ###
               ### GET /management/accounts/DExx/ebics_users
               ###

--- a/box/models/ebics_user.rb
+++ b/box/models/ebics_user.rb
@@ -83,6 +83,19 @@ module Box
       false
     end
 
+    def refresh_bank_keys!
+      Box.logger.info("Refresh bank keys for account #{id}")
+      client.HPB
+
+      self.encryption_keys = client.send(:dump_keys)
+      save
+      true
+    rescue StandardError => e
+      # TODO: show the error to the user
+      Box.logger.error("Failed to refresh bank keys for account #{id}: #{e}")
+      false
+    end
+
     def state
       if active?
         'active'


### PR DESCRIPTION
closes https://github.com/railslove/ebicsbox/issues/165 

This is the first step of tackling the issue that a bank updates their bank keys. 

Source: https://www.hamburger-volksbank.de/firmenkunden/zahlungsverkehr/service/bankschluesselwechsel-ebics.html

It mentioned that you need to execute HPB order again when the keys are rotated. 

This fix provides an endpoint that can be called so that the keys are updated. 

I tested it with GLS Bank. 

BEFORE calling the endpoint

direct_debits were in status failed due to 091008/EBICS_BANK_PUBKEY_UPDATE_REQUIRED - Bank key invalid

AFTER calling the endpoint

[{"at":"2021-07-29T10:01:34.176+00:00","status":"file_upload","reason":"TS01"},{"at":"2021-07-29T10:01:34.199+00:00","status":"es_verification","reason":"DS01"},{"at":"2021-07-29T10:01:34.254+00:00","status":"order_hac_final_pos","reason":""}]