### PR TITLE
:broom: Removes obsolete monkeypatch

### DIFF
--- a/box/business_processes/foreign_credit.rb
+++ b/box/business_processes/foreign_credit.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# king_dtaus is very old and needs this monkeypatch :(
-class BigDecimal; def initialize(value) = BigDecimal(value); end
-
 require "king_dtaus"
 require "ostruct"
 require_relative "../errors/business_process_failure"


### PR DESCRIPTION
Was not needed after I patched the gem itself 