### PR TITLE
ci: use correct tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action


### PR DESCRIPTION
## What changes are introduced?
Use correct tag

## Why are these changes introduced?
the tag version `v4` does not exist. Here was an copy and paste error

## How are these changes made?
Adjust gh action workflow