### PR TITLE
chore: add healthchecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.2
+- `[ENHANCEMENT]` Add container healthcheck
+
 ## 2.0.1
 - `[FIX]` Migrate to new sentry
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,3 +25,4 @@ RUN chmod 755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["bin/start", "all"]
+HEALTHCHECK --interval=30s --timeout=3s CMD bin/healthchecks/all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.3.2-slim
-RUN apt-get update && apt-get install -y git supervisor build-essential zlib1g-dev libpq-dev
+RUN apt-get update && apt-get install -y git supervisor build-essential zlib1g-dev libpq-dev curl
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 

--- a/bin/healthchecks/all
+++ b/bin/healthchecks/all
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+hasHealthyWebProcess() {
+  if curl -f "http://localhost:${PORT:-5000}/health"; then
+    exit 0
+  else
+    exit 1
+  fi
+}
+
+hasRunningSidekiqProcess() {
+  if [ $(bundle exec sidekiqmon processes | grep -Po '\d' | awk '{s+=$1} END {print s}') -gt 0 ]; then
+    exit 0
+  else
+    exit 1
+  fi
+}
+
+# Combined check
+if hasHealthyWebProcess && hasRunningSidekiqProcess; then
+  exit 0
+else
+  exit 1
+fi

--- a/bin/healthchecks/server
+++ b/bin/healthchecks/server
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SERVER_PORT="${PORT:-5000}" 
+
+curl -f "http://localhost:${SERVER_PORT}/health" || exit 1

--- a/bin/healthchecks/worker
+++ b/bin/healthchecks/worker
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+hasRunningSidekiqProcess() {
+  if [ $(bundle exec sidekiqmon processes | grep -Po '\d' | awk '{s+=$1} END {print s}') -gt 0 ]; then
+    exit 0
+  else
+    exit 1
+  fi
+}
+
+hasRunningSidekiqProcess

--- a/box/apis/healthcheck.rb
+++ b/box/apis/healthcheck.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "grape"
+require "grape-swagger"
+require "grape-swagger/entity"
+
+module Box
+  module Apis
+    class Healthcheck < Grape::API
+      version "v2", using: :header, vendor: "ebicsbox"
+      format :json
+
+      resource :health do
+        desc "Health check endpoint",
+          success: [{code: 200, message: "service ok"}],
+          failure: [{code: 500, message: "Internal server error"}]
+        get do
+          {status: "ok"}
+        end
+      end
+    end
+  end
+end

--- a/box/apis/v2/base.rb
+++ b/box/apis/v2/base.rb
@@ -4,6 +4,7 @@ require "grape"
 require "grape-swagger"
 require "grape-swagger/entity"
 
+require_relative "../healthcheck"
 require_relative "accounts"
 require_relative "credit_transfers"
 require_relative "direct_debits"
@@ -33,6 +34,7 @@ module Box
         mount Management::Organizations
         mount Management::Users
         mount Management::Webhooks
+        mount ::Box::Apis::Healthcheck
 
         add_swagger_documentation \
           doc_version: "v2",

--- a/config.ru
+++ b/config.ru
@@ -22,7 +22,7 @@ end
 if ENV["RACK_ENV"] == "production"
   unless ENV["DISABLE_SSL_FORCE"]
     require "rack/ssl-enforcer"
-    use Rack::SslEnforcer
+    use Rack::SslEnforcer, except: ["/health"]
   end
 
   # Log all requests in apache log file format

--- a/docker-compose.with_db.yml
+++ b/docker-compose.with_db.yml
@@ -71,6 +71,11 @@ services:
       retries: 5
   worker:
     build: .
+    healthcheck:
+      test: ["CMD", bin/healthchecks/worker]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     environment:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=postgresql://ebicsbox:password@db/ebicsbox

--- a/docker-compose.with_db.yml
+++ b/docker-compose.with_db.yml
@@ -64,6 +64,11 @@ services:
     networks:
       - ebicsbox_network
     build: .
+    healthcheck:
+      test: ["CMD", bin/healthchecks/server]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   worker:
     build: .
     environment:


### PR DESCRIPTION
## What changes are introduced?
add health checks for docker

## Why are these changes introduced?
the health check allows an automatic validation of the state of the container. That can be used for e.g. a load balancer.

## How are these changes made?
1. Add health endpoint for the web container
2. Use the sidekiq `stats` rake task for the worker container
## How was it tested? (optional)
_remove this section, when you don't add further information_

Some code, especially infrastructure code (say HELM or Kubernetes yaml files) are harder to test. So it’s important to let the reviewer know how you tested them in case you can’t check in tests. Alternatively, you can explain to the reviewer how to test it locally if necessary. Showing the results of tests you’ve run in this section if none are visible in the diff is also very helpful.

- [ ] Specs
- [x] Locally
- [ ] Staging