### PR TITLE
Fix/ruby imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1
+- `[FIX]` correct broken ruby import hierarchy. This was broken in Version `2.0`
+- `[FIX]` add http status 500 as swagger responses
+
 ## 2.1.0
 - `[ENHANCEMENT]` Allow the initial setup of the box to be performed via web interface `/setup`
 

--- a/box/apis/v2/credit_transfers.rb
+++ b/box/apis/v2/credit_transfers.rb
@@ -4,6 +4,8 @@ require "grape"
 
 require_relative "api_endpoint"
 require_relative "../../entities/v2/credit_transfer"
+require_relative "../../business_processes/credit"
+require_relative "../../business_processes/foreign_credit"
 require_relative "../../validations/unique_transaction_eref"
 require_relative "../../validations/length"
 require_relative "../../errors/business_process_failure"
@@ -98,10 +100,10 @@ module Box
 
             if sanitized_params[:currency] == "EUR"
               sanitized_params.reject! { |k, _v| k.in? %w[big country_code fee_handling] } # still related to workaround
-              Credit.v2_create!(current_user, account, sanitized_params)
+              BusinessProcesses::Credit.v2_create!(current_user, account, sanitized_params)
             else
               sanitized_params.reject! { |k, _v| k.in? %w[urgent] } # still related to workaround
-              ForeignCredit.v2_create!(current_user, account, sanitized_params)
+              BusinessProcesses::ForeignCredit.v2_create!(current_user, account, sanitized_params)
             end
 
             {message: "Credit transfer has been initiated successfully!"}

--- a/box/apis/v2/direct_debits.rb
+++ b/box/apis/v2/direct_debits.rb
@@ -4,6 +4,7 @@ require "grape"
 
 require_relative "api_endpoint"
 require_relative "../../entities/v2/direct_debit"
+require_relative "../../business_processes/direct_debit"
 require_relative "../../validations/unique_transaction_eref"
 require_relative "../../validations/length"
 require_relative "../../errors/business_process_failure"
@@ -90,7 +91,7 @@ module Box
 
           post do
             account = current_organization.find_account!(params[:account])
-            DirectDebit.v2_create!(current_user, account, declared(params))
+            BusinessProcesses::DirectDebit.v2_create!(current_user, account, declared(params))
             {message: "Direct debit has been initiated successfully!"}
           end
 

--- a/box/business_processes/credit.rb
+++ b/box/business_processes/credit.rb
@@ -8,57 +8,59 @@ require_relative "../errors/business_process_failure"
 require_relative "../queue"
 
 module Box
-  class Credit
-    def self.create!(account, params, user)
-      sct = SEPA::CreditTransfer.new(account.credit_pain_attributes_hash).tap do |credit|
-        credit.message_identification = "EBICS-BOX/#{SecureRandom.hex(11).upcase}"
-        credit.add_transaction(
-          name: params[:name],
-          bic: params[:bic],
-          iban: params[:iban],
-          amount: params[:amount] / 100.0,
-          reference: params[:eref],
-          remittance_information: params[:remittance_information],
-          requested_date: Time.at(params[:requested_date]).to_date,
-          batch_booking: false,
-          service_level: params[:service_level]
-        )
+  module BusinessProcesses
+    class Credit
+      def self.create!(account, params, user)
+        sct = SEPA::CreditTransfer.new(account.credit_pain_attributes_hash).tap do |credit|
+          credit.message_identification = "EBICS-BOX/#{SecureRandom.hex(11).upcase}"
+          credit.add_transaction(
+            name: params[:name],
+            bic: params[:bic],
+            iban: params[:iban],
+            amount: params[:amount] / 100.0,
+            reference: params[:eref],
+            remittance_information: params[:remittance_information],
+            requested_date: Time.at(params[:requested_date]).to_date,
+            batch_booking: false,
+            service_level: params[:service_level]
+          )
+        end
+
+        if sct.valid?
+          Queue.execute_credit(
+            account_id: account.id,
+            user_id: user.id,
+            payload: Base64.strict_encode64(sct.to_xml("pain.001.001.03")),
+            eref: params[:eref],
+            currency: "EUR",
+            amount: params[:amount],
+            metadata: {
+              **params.slice(:name, :iban, :bic, :reference),
+              execution_date: params[:execution_date]&.iso8601
+            }
+          )
+        else
+          raise Box::BusinessProcessFailure, sct.errors
+        end
+      rescue ArgumentError => e
+        # TODO: Will be fixed upstream in the sepa_king gem by us
+        raise Box::BusinessProcessFailure.new({base: e.message}, "Invalid data")
       end
 
-      if sct.valid?
-        Queue.execute_credit(
-          account_id: account.id,
-          user_id: user.id,
-          payload: Base64.strict_encode64(sct.to_xml("pain.001.001.03")),
-          eref: params[:eref],
-          currency: "EUR",
-          amount: params[:amount],
-          metadata: {
-            **params.slice(:name, :iban, :bic, :reference),
-            execution_date: params[:execution_date]&.iso8601
-          }
-        )
-      else
-        raise Box::BusinessProcessFailure, sct.errors
+      def self.v2_create!(user, account, params)
+        # EBICS requires a unix timestamp
+        params[:requested_date] = params[:execution_date].to_time.to_i
+
+        # Transform a few params
+        params[:amount] = params[:amount_in_cents]
+        params[:eref] = params[:end_to_end_reference]
+        params[:remittance_information] = params[:reference]
+
+        # Set urgent flag or fall back to SEPA
+        params[:service_level] = params[:urgent] ? "URGP" : "SEPA"
+
+        create!(account, params, user)
       end
-    rescue ArgumentError => e
-      # TODO: Will be fixed upstream in the sepa_king gem by us
-      raise Box::BusinessProcessFailure.new({base: e.message}, "Invalid data")
-    end
-
-    def self.v2_create!(user, account, params)
-      # EBICS requires a unix timestamp
-      params[:requested_date] = params[:execution_date].to_time.to_i
-
-      # Transform a few params
-      params[:amount] = params[:amount_in_cents]
-      params[:eref] = params[:end_to_end_reference]
-      params[:remittance_information] = params[:reference]
-
-      # Set urgent flag or fall back to SEPA
-      params[:service_level] = params[:urgent] ? "URGP" : "SEPA"
-
-      create!(account, params, user)
     end
   end
 end

--- a/box/business_processes/direct_debit.rb
+++ b/box/business_processes/direct_debit.rb
@@ -8,55 +8,57 @@ require_relative "../errors/business_process_failure"
 require_relative "../queue"
 
 module Box
-  class DirectDebit
-    def self.create!(account, params, user)
-      sdd = SEPA::DirectDebit.new(account.pain_attributes_hash).tap do |debit|
-        debit.message_identification = "EBICS-BOX/#{SecureRandom.hex(11).upcase}"
-        debit.add_transaction(
-          name: params[:name],
-          bic: params[:bic],
-          iban: params[:iban],
-          amount: params[:amount] / 100.0,
-          instruction: params[:instruction],
-          mandate_id: params[:mandate_id],
-          mandate_date_of_signature: Time.at(params[:mandate_signature_date]).to_date,
-          local_instrument: params[:instrument],
-          sequence_type: params[:sequence_type],
-          reference: params[:eref],
-          remittance_information: params[:remittance_information],
-          requested_date: Time.at(params[:requested_date]).to_date,
-          batch_booking: true
-        )
+  module BusinessProcesses
+    class DirectDebit
+      def self.create!(account, params, user)
+        sdd = SEPA::DirectDebit.new(account.pain_attributes_hash).tap do |debit|
+          debit.message_identification = "EBICS-BOX/#{SecureRandom.hex(11).upcase}"
+          debit.add_transaction(
+            name: params[:name],
+            bic: params[:bic],
+            iban: params[:iban],
+            amount: params[:amount] / 100.0,
+            instruction: params[:instruction],
+            mandate_id: params[:mandate_id],
+            mandate_date_of_signature: Time.at(params[:mandate_signature_date]).to_date,
+            local_instrument: params[:instrument],
+            sequence_type: params[:sequence_type],
+            reference: params[:eref],
+            remittance_information: params[:remittance_information],
+            requested_date: Time.at(params[:requested_date]).to_date,
+            batch_booking: true
+          )
+        end
+
+        if sdd.valid?
+          Queue.execute_debit(
+            account_id: account.id,
+            user_id: user.id,
+            payload: Base64.strict_encode64(sdd.to_xml("pain.008.001.02")),
+            amount: params[:amount],
+            eref: params[:eref],
+            instrument: params[:instrument]
+          )
+        else
+          raise Box::BusinessProcessFailure, sdd.errors
+        end
+      rescue ArgumentError => e
+        # TODO: Will be fixed upstream in the sepa_king gem by us
+        raise Box::BusinessProcessFailure.new({base: e.message}, "Invalid data")
       end
 
-      if sdd.valid?
-        Queue.execute_debit(
-          account_id: account.id,
-          user_id: user.id,
-          payload: Base64.strict_encode64(sdd.to_xml("pain.008.001.02")),
-          amount: params[:amount],
-          eref: params[:eref],
-          instrument: params[:instrument]
-        )
-      else
-        raise Box::BusinessProcessFailure, sdd.errors
+      def self.v2_create!(user, account, params)
+        # EBICS requires a unix timestamp
+        params[:requested_date] = params[:execution_date].to_time.to_i
+
+        # Transform a few params
+        params[:amount] = params[:amount_in_cents]
+        params[:eref] = params[:end_to_end_reference]
+        params[:remittance_information] = params[:reference]
+
+        # Execute v1 method
+        create!(account, params, user)
       end
-    rescue ArgumentError => e
-      # TODO: Will be fixed upstream in the sepa_king gem by us
-      raise Box::BusinessProcessFailure.new({base: e.message}, "Invalid data")
-    end
-
-    def self.v2_create!(user, account, params)
-      # EBICS requires a unix timestamp
-      params[:requested_date] = params[:execution_date].to_time.to_i
-
-      # Transform a few params
-      params[:amount] = params[:amount_in_cents]
-      params[:eref] = params[:end_to_end_reference]
-      params[:remittance_information] = params[:reference]
-
-      # Execute v1 method
-      create!(account, params, user)
     end
   end
 end

--- a/box/business_processes/foreign_credit.rb
+++ b/box/business_processes/foreign_credit.rb
@@ -5,88 +5,90 @@ require "ostruct"
 require_relative "../errors/business_process_failure"
 
 module Box
-  class ForeignCredit
-    class Payload < OpenStruct
-      def sender
-        KingDta::Account.new(
-          owner_name: account.name,
-          bank_number: account.bank_number,
-          owner_country_code: account.bank_country_code,
-          bank_account_number: account.bank_account_number
-        )
-      end
+  module BusinessProcesses
+    class ForeignCredit
+      class Payload < OpenStruct
+        def sender
+          KingDta::Account.new(
+            owner_name: account.name,
+            bank_number: account.bank_number,
+            owner_country_code: account.bank_country_code,
+            bank_account_number: account.bank_account_number
+          )
+        end
 
-      def receiver
-        KingDta::Account.new(
-          bank_bic: params[:bic],
-          owner_name: params[:name],
-          owner_country_code: params[:country_code],
-          ** account_number
-        )
-      end
+        def receiver
+          KingDta::Account.new(
+            bank_bic: params[:bic],
+            owner_name: params[:name],
+            owner_country_code: params[:country_code],
+            ** account_number
+          )
+        end
 
-      def account_number
-        if /[A-Z]{2}/.match?(params[:iban])
-          {bank_iban: params[:iban]}
-        else
-          {bank_account_number: params[:iban]}
+        def account_number
+          if /[A-Z]{2}/.match?(params[:iban])
+            {bank_iban: params[:iban]}
+          else
+            {bank_account_number: params[:iban]}
+          end
+        end
+
+        def amount
+          params[:amount] / 100.0
+        end
+
+        def fee_handling
+          {
+            split: "00",
+            sender: "01",
+            receiver: "02"
+          }[params[:fee_handling]]
+        end
+
+        def booking
+          KingDta::Booking.new(receiver, amount, params[:eref], nil, params[:currency]).tap do |booking|
+            booking.payment_type = "00"
+            booking.charge_bearer_code = fee_handling
+          end
+        end
+
+        def create
+          azv = KingDta::Dtazv.new(params[:execution_date])
+          azv.account = sender
+          azv.add(booking)
+
+          azv.create
         end
       end
 
-      def amount
-        params[:amount] / 100.0
+      def self.v2_create!(user, account, params)
+        params[:requested_date] = params[:execution_date].to_time.to_i
+
+        # Transform a few params
+        params[:amount] = params[:amount_in_cents]
+        params[:eref] = params[:end_to_end_reference]
+        params[:remittance_information] = params[:reference]
+
+        payload = Payload.new(account: account, params: params)
+
+        Queue.execute_credit(
+          account_id: account.id,
+          user_id: user.id,
+          payload: Base64.strict_encode64(payload.create),
+          eref: params[:eref],
+          currency: params[:currency],
+          amount: params[:amount],
+          metadata: {
+            **params.slice(:name, :iban, :bic, :reference, :country_code),
+            execution_date: params[:execution_date]&.iso8601,
+            fee_handling: params[:fee_handling]&.to_s
+          }
+        )
+      rescue ArgumentError => e
+        # TODO: Will be fixed upstream in the sepa_king gem by us
+        raise Box::BusinessProcessFailure.new({base: e.message}, "Invalid data")
       end
-
-      def fee_handling
-        {
-          split: "00",
-          sender: "01",
-          receiver: "02"
-        }[params[:fee_handling]]
-      end
-
-      def booking
-        KingDta::Booking.new(receiver, amount, params[:eref], nil, params[:currency]).tap do |booking|
-          booking.payment_type = "00"
-          booking.charge_bearer_code = fee_handling
-        end
-      end
-
-      def create
-        azv = KingDta::Dtazv.new(params[:execution_date])
-        azv.account = sender
-        azv.add(booking)
-
-        azv.create
-      end
-    end
-
-    def self.v2_create!(user, account, params)
-      params[:requested_date] = params[:execution_date].to_time.to_i
-
-      # Transform a few params
-      params[:amount] = params[:amount_in_cents]
-      params[:eref] = params[:end_to_end_reference]
-      params[:remittance_information] = params[:reference]
-
-      payload = Payload.new(account: account, params: params)
-
-      Queue.execute_credit(
-        account_id: account.id,
-        user_id: user.id,
-        payload: Base64.strict_encode64(payload.create),
-        eref: params[:eref],
-        currency: params[:currency],
-        amount: params[:amount],
-        metadata: {
-          **params.slice(:name, :iban, :bic, :reference, :country_code),
-          execution_date: params[:execution_date]&.iso8601,
-          fee_handling: params[:fee_handling]&.to_s
-        }
-      )
-    rescue ArgumentError => e
-      # TODO: Will be fixed upstream in the sepa_king gem by us
-      raise Box::BusinessProcessFailure.new({base: e.message}, "Invalid data")
     end
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -8,12 +8,15 @@ if ENV["SENTRY_DSN"]
     # Raven reports on the following environments
     config.enabled_environments = %w[development staging production]
   end
+
+  use Sentry::Rack::CaptureExceptions
 end
 
 if ENV["ROLLBAR_ACCESS_TOKEN"]
   require "rollbar/middleware/rack"
   Rollbar.configure do |config|
     config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
+    config.environment = ENV["RACK_ENV"]
   end
 
   use Rollbar::Middleware::Rack

--- a/spec/adapters/fake_spec.rb
+++ b/spec/adapters/fake_spec.rb
@@ -53,7 +53,7 @@ module Box
         end
 
         context "auto accept any credits and create statements" do
-          let(:run_job) { Credit.create!(account, valid_payload.merge(amount: 100_00), user) }
+          let(:run_job) { BusinessProcesses::Credit.create!(account, valid_payload.merge(amount: 100_00), user) }
           before do
             Sidekiq::Testing.inline!
           end
@@ -78,7 +78,7 @@ module Box
         end
 
         context "amounts" do
-          let(:run_job) { Credit.create!(account, valid_payload.merge(amount: 251_995), user) }
+          let(:run_job) { BusinessProcesses::Credit.create!(account, valid_payload.merge(amount: 251_995), user) }
 
           it "sets correct statement account" do
             run_job
@@ -108,7 +108,7 @@ module Box
         end
 
         context "auto accept any direct debits and create statements" do
-          let(:run_job) { DirectDebit.create!(account, valid_payload.merge(amount: 100_00), user) }
+          let(:run_job) { BusinessProcesses::DirectDebit.create!(account, valid_payload.merge(amount: 100_00), user) }
           before do
             Sidekiq::Testing.inline!
           end
@@ -138,7 +138,7 @@ module Box
         end
 
         context "amounts" do
-          let(:run_job) { DirectDebit.create!(account, valid_payload.merge(amount: 251_995), user) }
+          let(:run_job) { BusinessProcesses::DirectDebit.create!(account, valid_payload.merge(amount: 251_995), user) }
 
           it "sets correct statement account" do
             run_job

--- a/spec/apis/v2/credit_transfers_spec.rb
+++ b/spec/apis/v2/credit_transfers_spec.rb
@@ -263,12 +263,12 @@ module Box
         end
 
         it "triggers a credit transfer" do
-          expect(Credit).to receive(:create!)
+          expect(BusinessProcesses::Credit).to receive(:create!)
           post "/credit_transfers", valid_attributes, TestHelpers::VALID_HEADERS
         end
 
         it "triggers a credit transfer without bic" do
-          expect(Credit).to receive(:create!)
+          expect(BusinessProcesses::Credit).to receive(:create!)
           post "/credit_transfers", valid_attributes.except(:bic), TestHelpers::VALID_HEADERS
         end
 
@@ -278,7 +278,7 @@ module Box
         end
 
         it "transforms parameters so they are understood by credit business process" do
-          expect(Credit).to receive(:create!).with(account, anything, user)
+          expect(BusinessProcesses::Credit).to receive(:create!).with(account, anything, user)
           post "/credit_transfers", valid_attributes, TestHelpers::VALID_HEADERS
         end
 
@@ -290,14 +290,14 @@ module Box
         end
 
         it "ignores fee_handling & country_code flag" do
-          allow(Credit).to receive(:v2_create!).and_return(true)
+          allow(BusinessProcesses::Credit).to receive(:v2_create!).and_return(true)
           post "/credit_transfers", valid_attributes.merge(fee_handling: :split, country_code: "FooBar"), TestHelpers::VALID_HEADERS
 
           expected_attributes = valid_attributes
             .merge(reference: nil, execution_date: Date.today, urgent: false, currency: "EUR")
             .stringify_keys
 
-          expect(Credit).to have_received(:v2_create!).with(anything, anything, expected_attributes)
+          expect(BusinessProcesses::Credit).to have_received(:v2_create!).with(anything, anything, expected_attributes)
         end
 
         context "foreign currency" do
@@ -312,14 +312,14 @@ module Box
         end
 
         it "ignores urgent flag" do
-          allow(ForeignCredit).to receive(:v2_create!).and_return(true)
+          allow(BusinessProcesses::ForeignCredit).to receive(:v2_create!).and_return(true)
           post "/credit_transfers", valid_attributes_foreign.merge(urgent: true), TestHelpers::VALID_HEADERS
 
           expected_attributes = valid_attributes_foreign
             .merge(reference: nil, execution_date: Date.today, fee_handling: :split)
             .stringify_keys
 
-          expect(ForeignCredit).to have_received(:v2_create!).with(anything, anything, expected_attributes)
+          expect(BusinessProcesses::ForeignCredit).to have_received(:v2_create!).with(anything, anything, expected_attributes)
         end
       end
     end

--- a/spec/apis/v2/direct_debits_spec.rb
+++ b/spec/apis/v2/direct_debits_spec.rb
@@ -248,17 +248,17 @@ module Box
         end
 
         it "triggers a debit transfer" do
-          expect(DirectDebit).to receive(:create!)
+          expect(BusinessProcesses::DirectDebit).to receive(:create!)
           post "/direct_debits", valid_attributes, valid_debit_headers
         end
 
         it "triggers a debit transfer without bic" do
-          expect(DirectDebit).to receive(:create!)
+          expect(BusinessProcesses::DirectDebit).to receive(:create!)
           post "/direct_debits", valid_attributes.except(:bic), valid_debit_headers
         end
 
         it "transforms parameters so they are understood by debit business process" do
-          expect(DirectDebit).to receive(:create!).with(account, anything, user)
+          expect(BusinessProcesses::DirectDebit).to receive(:create!).with(account, anything, user)
           post "/direct_debits", valid_attributes, valid_debit_headers
         end
 


### PR DESCRIPTION
## What changes are introduced?
1. Fix broken ruby imports
2. Add HTTP status 500 to swagger

## Why are these changes introduced?
1. Due to the broken imports it was not possible to create new `credit_transfers` and `direct_debits` as of version `2.0`
2. Any HTTP 500 result broke the swagger client since that was an unknown response

## How are these changes made?
1. Make explicit imports to fix the import hierarchy
2. Add 500 as valid response to swagger

## How was it tested? (optional)
_remove this section, when you don't add further information_

Some code, especially infrastructure code (say HELM or Kubernetes yaml files) are harder to test. So it’s important to let the reviewer know how you tested them in case you can’t check in tests. Alternatively, you can explain to the reviewer how to test it locally if necessary. Showing the results of tests you’ve run in this section if none are visible in the diff is also very helpful.

- [ ] Specs
- [x] Locally
- [ ] Staging