### PR TITLE
fix: correct postgres docker healthcheck

### DIFF
--- a/docker-compose.with_db.yml
+++ b/docker-compose.with_db.yml
@@ -24,7 +24,7 @@ services:
     networks:
       - ebicsbox_network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER"]
+      test: ["CMD-SHELL", "pg_isready", "-U", "postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -40,7 +40,7 @@ services:
     networks:
       - ebicsbox_network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER"]
+      test: ["CMD-SHELL", "pg_isready", "-U", "postgres"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION


## What changes are introduced?
use the default user for healthcheck

## Why are these changes introduced?
since this is only for development we can use the default user instead of expecting the user to be set via env variable

## How are these changes made?
adjust healthcheck

## How was it tested? (optional)
_remove this section, when you don't add further information_

Some code, especially infrastructure code (say HELM or Kubernetes yaml files) are harder to test. So it’s important to let the reviewer know how you tested them in case you can’t check in tests. Alternatively, you can explain to the reviewer how to test it locally if necessary. Showing the results of tests you’ve run in this section if none are visible in the diff is also very helpful.

- [ ] Specs
- [x] Locally
- [ ] Staging