### PR TITLE
fix: add missing parameter type

### DIFF
--- a/box/apis/v2/accounts.rb
+++ b/box/apis/v2/accounts.rb
@@ -131,6 +131,7 @@ module Box
             body_name: "body"
 
           params do
+            requires :iban, type: String
             optional :name, type: String, allow_blank: false, desc: "Name of account", documentation: {param_type: "body"}
             optional :descriptor, type: String, allow_blank: false, desc: "Internal descriptor of account"
             optional :creditor_identifier, type: String, desc: "Creditor identifier required for direct debits"


### PR DESCRIPTION
## What changes are introduced?
Set parameter type explicity as `string`

## Why are these changes introduced?
when the parameter is missing the iban is expected as an integer

## How are these changes made?
Add missing swagger block

## How was it tested? (optional)
_remove this section, when you don't add further information_

Some code, especially infrastructure code (say HELM or Kubernetes yaml files) are harder to test. So it’s important to let the reviewer know how you tested them in case you can’t check in tests. Alternatively, you can explain to the reviewer how to test it locally if necessary. Showing the results of tests you’ve run in this section if none are visible in the diff is also very helpful.

- [ ] Specs
- [x] Locally
- [ ] Staging


## Hints for Reviews? (optional)
_remove this section, when you don't attach further hints_

<details>
<summary>Screenshots, Sample Data</summary>

| Before | After |
| ------ | ----- |
|<img width="1434" alt="image" src="https://github.com/user-attachments/assets/85766799-f3ed-490c-ae31-38cd86e7c0b4" />|<img width="1455" alt="image" src="https://github.com/user-attachments/assets/f226d9a9-b9df-42a1-9cf7-02eeb82be1e7" />|

</details>